### PR TITLE
Phase 2: Refactor user registration to use service layer

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -51,25 +51,6 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
                 'password_confirm': 'Passwords do not match'
             })
         return attrs
-    
-    def create(self, validated_data):
-        """Create user with hashed password."""
-        validated_data.pop('password_confirm')
-        
-        user = User.objects.create_user(
-            email=validated_data['email'],
-            password=validated_data['password'],
-            display_name=validated_data.get('display_name', '')
-        )
-        
-        # Generate verification token
-        import secrets
-        user.verification_token = secrets.token_urlsafe(32)
-        user.save(update_fields=['verification_token'])
-        
-        # TODO: Send verification email
-        
-        return user
 
 
 class UserLoginSerializer(serializers.Serializer):

--- a/apps/accounts/services/__init__.py
+++ b/apps/accounts/services/__init__.py
@@ -9,8 +9,10 @@ from .exceptions import (
     UserNotFoundError,
     PasswordConfirmationError,
 )
+from .user_registration import register_user
 
 __all__ = [
+    # Exceptions
     'AccountsServiceError',
     'UserRegistrationError',
     'InvalidCredentialsError',
@@ -18,4 +20,6 @@ __all__ = [
     'InvalidTokenError',
     'UserNotFoundError',
     'PasswordConfirmationError',
+    # Services
+    'register_user',
 ]

--- a/apps/accounts/services/user_registration.py
+++ b/apps/accounts/services/user_registration.py
@@ -1,0 +1,53 @@
+"""User registration service."""
+
+from django.db import transaction
+from django.contrib.auth import get_user_model
+import secrets
+
+from .exceptions import UserRegistrationError
+
+User = get_user_model()
+
+
+@transaction.atomic
+def register_user(
+    *,
+    email: str,
+    password: str,
+    display_name: str = ""
+) -> User:
+    """
+    Register a new user with email verification token.
+
+    Args:
+        email: User's email address
+        password: User's password (will be hashed)
+        display_name: Optional display name
+
+    Returns:
+        Created User instance
+
+    Raises:
+        UserRegistrationError: If registration fails
+    """
+    try:
+        # Create user with hashed password
+        user = User.objects.create_user(
+            email=email,
+            password=password,
+            display_name=display_name
+        )
+
+        # Generate verification token
+        user.verification_token = secrets.token_urlsafe(32)
+        user.save(update_fields=['verification_token'])
+
+        # TODO: Send verification email (outside transaction)
+        # transaction.on_commit(
+        #     lambda: send_verification_email(user)
+        # )
+
+        return user
+
+    except Exception as e:
+        raise UserRegistrationError(f"Registration failed: {str(e)}")


### PR DESCRIPTION
Changes:
- Create register_user() service with @transaction.atomic
- Move business logic from serializer to service
- Update register view to call service instead of serializer.save()
- Simplify UserRegistrationSerializer (remove create() method)
- Add proper exception handling with UserRegistrationError

Benefits:
- Clear separation of concerns (view handles HTTP, service handles business logic)
- Transaction safety for user creation and token generation
- Better testability (service can be tested independently)
- Follows DRF best practices architecture

Phase 2 of 9 complete.