### PR TITLE
Phase 3: Refactor authentication with concurrency protection

### DIFF
--- a/apps/accounts/services/__init__.py
+++ b/apps/accounts/services/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
     PasswordConfirmationError,
 )
 from .user_registration import register_user
+from .user_authentication import authenticate_user
 
 __all__ = [
     # Exceptions
@@ -22,4 +23,5 @@ __all__ = [
     'PasswordConfirmationError',
     # Services
     'register_user',
+    'authenticate_user',
 ]

--- a/apps/accounts/services/user_authentication.py
+++ b/apps/accounts/services/user_authentication.py
@@ -1,0 +1,52 @@
+"""User authentication service."""
+
+from django.db import transaction
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from .exceptions import InvalidCredentialsError, InactiveAccountError
+
+User = get_user_model()
+
+
+@transaction.atomic
+def authenticate_user(*, email: str, password: str) -> User:
+    """
+    Authenticate user with email and password.
+
+    Uses select_for_update() to prevent race conditions when updating last_login.
+
+    Args:
+        email: User's email
+        password: User's password
+
+    Returns:
+        Authenticated User instance
+
+    Raises:
+        InvalidCredentialsError: If credentials are invalid
+        InactiveAccountError: If account is deactivated
+    """
+    # Get user with lock to prevent race conditions on last_login
+    try:
+        user = (
+            User.objects
+            .select_for_update()
+            .get(email=email)
+        )
+    except User.DoesNotExist:
+        raise InvalidCredentialsError("Invalid email or password")
+
+    # Check password
+    if not user.check_password(password):
+        raise InvalidCredentialsError("Invalid email or password")
+
+    # Check if active
+    if not user.is_active:
+        raise InactiveAccountError("Account is deactivated")
+
+    # Update last login
+    user.last_login = timezone.now()
+    user.save(update_fields=['last_login'])
+
+    return user


### PR DESCRIPTION
Changes:
- Create authenticate_user() service with @transaction.atomic
- Add select_for_update() to prevent race conditions on last_login
- Move authentication logic from view to service
- Update login view to call service
- Remove Django authenticate() in favor of custom service
- Add proper exception handling

Benefits:
- Concurrency protection with row-level locking
- Transaction safety for login operations
- Business logic separated from HTTP layer
- Better testability
- Prevents race conditions on last_login updates

Phase 3 of 9 complete.