### PR TITLE
Fix: FAB menu add-bean and add-review now work on all pages

### DIFF
--- a/frontend/js/bottom-nav.js
+++ b/frontend/js/bottom-nav.js
@@ -35,8 +35,8 @@ function generateBottomNavHTML(activePage = null) {
 
     <!-- FAB Menu -->
     <div class="fab-menu" id="fabMenu">
-        <button type="button" class="fab-menu-item" id="fabAddBean"><span>☕</span><span>Pridat kavu</span></button>
-        <button type="button" class="fab-menu-item" id="fabAddReview"><span>⭐</span><span>Nove hodnoceni</span></button>
+        <a href="/beans/" class="fab-menu-item" id="fabAddBean"><span>☕</span><span>Pridat kavu</span></a>
+        <a href="/review/create/" class="fab-menu-item" id="fabAddReview"><span>⭐</span><span>Nove hodnoceni</span></a>
         <a href="/purchases/create/" class="fab-menu-item" id="fabAddPurchase"><span>🛒</span><span>Zaznamenat nakup</span></a>
     </div>
 
@@ -93,8 +93,6 @@ function initBottomNav() {
     const fabBtn = document.getElementById('fabBtn');
     const fabMenu = document.getElementById('fabMenu');
     const fabOverlay = document.getElementById('fabOverlay');
-    const fabAddBean = document.getElementById('fabAddBean');
-    const fabAddReview = document.getElementById('fabAddReview');
 
     if (!fabBtn || !fabMenu || !fabOverlay) {
         console.warn('Bottom nav elements not found');
@@ -118,22 +116,14 @@ function initBottomNav() {
     fabBtn.addEventListener('click', toggleFab);
     fabOverlay.addEventListener('click', closeFab);
 
-    // Handle FAB menu items that need modals
-    if (fabAddBean) {
-        fabAddBean.addEventListener('click', () => {
+    // FAB menu items are now links, they'll navigate automatically
+    // Close FAB when any menu item is clicked
+    const fabMenuItems = fabMenu.querySelectorAll('.fab-menu-item');
+    fabMenuItems.forEach(item => {
+        item.addEventListener('click', () => {
             closeFab();
-            // Dispatch event for pages to handle
-            window.dispatchEvent(new CustomEvent('fab:add-bean'));
         });
-    }
-
-    if (fabAddReview) {
-        fabAddReview.addEventListener('click', () => {
-            closeFab();
-            // Dispatch event for pages to handle
-            window.dispatchEvent(new CustomEvent('fab:add-review'));
-        });
-    }
+    });
 
     // Close on escape
     document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
Problem: FAB menu 'Add Bean' and 'Add Review' buttons only worked on dashboard, not on other pages (groups, library, purchases, bean detail).

Root cause: Other pages use bottom-nav.js which dispatched custom events (fab:add-bean, fab:add-review) but pages didn't have listeners for these events.

Solution: Changed FAB menu items from buttons to links:
- Add Bean → /beans/ (catalog page)
- Add Review → /review/create/ (review creation page)
- Add Purchase → /purchases/create/ (already working)

Benefits:
✅ Works universally on ALL pages
✅ No need for event listeners on each page
✅ Simple and consistent navigation
✅ Users can use browser back button

Changes:
- frontend/js/bottom-nav.js:
  * Changed fabAddBean and fabAddReview from buttons to anchor links
  * Removed custom event dispatching code
  * Simplified initBottomNav() function
  * FAB menu closes on click for smooth navigation