### PR TITLE
Fix: Preserve invite code case-sensitivity for security

### DIFF
--- a/frontend/groups_create.html
+++ b/frontend/groups_create.html
@@ -563,7 +563,7 @@
             inviteCodeError.classList.remove('visible');
             inviteCodeInput.classList.remove('input-error');
 
-            const inviteCode = inviteCodeInput.value.trim().toUpperCase();
+            const inviteCode = inviteCodeInput.value.trim();
 
             if (!inviteCode) {
                 inviteCodeInput.classList.add('input-error');


### PR DESCRIPTION
Problem: Users got 'invalid invite code' errors when joining groups.
Root cause: Frontend uppercased input while backend expected exact case match.

Initial approach (reverted): Made backend case-insensitive
- Reduced security by cutting keyspace from 62 chars to 36 chars
- Bad: 'AbC123' and 'abc123' would be treated as same code

Correct approach: Remove frontend uppercasing
- Maintains full security of generated codes
- Invite codes preserve original mixed-case from secrets.token_urlsafe()
- Users must enter code with correct case (copy-paste friendly)

Changes:
- frontend/groups_create.html:566 - Remove .toUpperCase()
- apps/groups/services/invite_management.py - Keep case-sensitive comparison