### PR TITLE
Fix: Make group library beans clickable and handle missing beans

### DIFF
--- a/frontend/group_detail.html
+++ b/frontend/group_detail.html
@@ -588,19 +588,29 @@
                 let html = '';
                 library.forEach(entry => {
                     const bean = entry.coffeebean;
+
+                    // Skip if bean is missing or inactive
+                    if (!bean || !bean.id) {
+                        return;
+                    }
+
+                    const beanUrl = `/beans/${bean.id}/`;
+
                     html += `
                         <div class="library-item">
-                            <div class="bean-icon">☕</div>
-                            <div class="bean-info">
-                                <div class="bean-name">${escapeHtml(bean.name)}</div>
-                                <div class="bean-roastery">${escapeHtml(bean.roastery_name || 'Neznama prazirna')}</div>
-                            </div>
-                            ${bean.avg_rating ? `
-                                <div class="bean-rating">
-                                    <span>★</span>
-                                    <span>${bean.avg_rating.toFixed(1)}</span>
+                            <a href="${beanUrl}" style="display: contents; color: inherit; text-decoration: none;">
+                                <div class="bean-icon">☕</div>
+                                <div class="bean-info">
+                                    <div class="bean-name">${escapeHtml(bean.name)}</div>
+                                    <div class="bean-roastery">${escapeHtml(bean.roastery_name || 'Neznama prazirna')}</div>
                                 </div>
-                            ` : ''}
+                                ${bean.avg_rating ? `
+                                    <div class="bean-rating">
+                                        <span>★</span>
+                                        <span>${bean.avg_rating.toFixed(1)}</span>
+                                    </div>
+                                ` : ''}
+                            </a>
                         </div>
                     `;
                 });


### PR DESCRIPTION
Problem: Group library showed error 'Chyba pri nacitani knihovny' Root causes:
1. Missing null checks - if bean was deleted/inactive, accessing bean.name threw error
2. Library items weren't clickable - no navigation to bean details

Solution:
- Add null/undefined check for entry.coffeebean before rendering
- Skip entries with missing or inactive beans
- Wrap each library item in anchor tag linking to /beans/{id}/
- Same pattern as general library (beans.html)

Now group library works like general library:
✅ Shows list of beans added to group
✅ Clickable items navigate to bean details
✅ Handles edge cases (deleted/inactive beans)